### PR TITLE
Update resource loading

### DIFF
--- a/islandora_cwrc_writer.module
+++ b/islandora_cwrc_writer.module
@@ -273,21 +273,7 @@ function islandora_cwrc_writer_libraries_info() {
 //      ),
       'files' => array(
         'js' => array(
-          //'js/config.js' => $default_js_properties,
-          //'js/lib/require/require.js' => $default_js_properties,
-          //'js/layout.js' => $default_js_properties,
           'js/app.js' => $default_js_properties,
-        ),
-        'css' => array(
-          'css/style.css' => $default_css_properties + array('basename' => 'cwrc.style.css'),
-          //'css/islandora_style.css' => $default_css_properties,
-          'css/layout-default-latest.css' => $default_css_properties,
-          'css/prism.css' => $default_css_properties,
-          'css/cwrc12/jquery-ui.css' => $default_css_properties,
-          'css/bootstrap/css/bootstrap.css' => $default_css_properties,
-          //'css/cD/css/datepicker.css' => $default_css_properties,
-          'css/cD/css/font-awesome.css' => $default_css_properties,
-          'css/cD/css/cD.css' => $default_css_properties,
         ),
       ),
     ),

--- a/js/islandora_cwrc_writer.js
+++ b/js/islandora_cwrc_writer.js
@@ -98,6 +98,7 @@ Drupal.CWRCWriter = Drupal.CWRCWriter || {};
          *
          * @see Delegator.saveAndExit
          */
+      // TODO unused?
         var saveAndExit = function(callback) {
             var docText = writer.converter.getDocumentContent(true);
             $.ajax({


### PR DESCRIPTION
These changes are to reflect the way CSS is now loaded in cwrc-writer. Instead of having to include the CSS manually, cwrc-writer itself takes care of adding the relevant links.